### PR TITLE
Fix license badge to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libnostr-c
 
-[![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](https://www.gnu.org/licenses/lgpl-2.1)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![C99](https://img.shields.io/badge/C-99-blue.svg)](https://en.wikipedia.org/wiki/C99)
 
 *A lightweight, portable C library for the Nostr protocol with native Lightning Network integration*


### PR DESCRIPTION
The README license badge showed LGPL v2.1, but both the LICENSE file and the README's License section state MIT. This updates the badge to MIT so it matches.