### PR TITLE
Fix Windows CI by removing hardcoded VS 2022 generator

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,7 +43,6 @@
         {
             "name": "win-base",
             "hidden": true,
-            "generator": "Visual Studio 17 2022",
             "architecture": "x64",
             "binaryDir": "${sourceDir}/build/windows",
             "cacheVariables": {


### PR DESCRIPTION
## Problem

The `build-windows` job fails at the CMake configure step:

```
CMake Error at CMakeLists.txt:62 (project):
  Generator
    Visual Studio 17 2022
  could not find any instance of Visual Studio.
```

GitHub's `windows-latest` runners now ship **Visual Studio 18 2026** (MSVC 19.51), and Visual Studio 17 2022 is no longer installed. The `win-base` preset hardcoded `Visual Studio 17 2022` as the generator, so configure could not find it. The secp256k1 install step already builds fine because it uses CMake's default generator, which auto-detects VS 18 2026.

## Fix

Remove the hardcoded `generator` from the `win-base` preset so CMake auto-detects the latest installed Visual Studio. The `architecture: x64` field continues to work with the default VS generator.