### PR TITLE
Let the ESP32 RNG report failure like every other backend

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -8,9 +8,6 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/sha256.h>
-#ifdef ESP_PLATFORM
-#include <esp_random.h>
-#endif
 #else
 #include <openssl/sha.h>
 #include <openssl/rand.h>

--- a/src/key.c
+++ b/src/key.c
@@ -51,7 +51,49 @@ static BOOL CALLBACK init_lock_callback(PINIT_ONCE InitOnce, PVOID Parameter, PV
 #else
 static pthread_mutex_t ctx_init_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif
+/*
+ * Deliberately a SEPARATE lock from ctx_init_lock. nostr_init() holds
+ * ctx_init_lock while it calls nostr_random_bytes() to seed the noscrypt
+ * context, so if the RNG took ctx_init_lock it would re-enter a non-recursive
+ * mutex and hang on the very first API call. ESP-IDF's pthread mutexes are
+ * PTHREAD_MUTEX_NORMAL by default and block forever rather than returning
+ * EDEADLK, and NOSTR_FEATURE_THREADING is compiled in on ESP (it is tested with
+ * #ifdef and defined as 0), so this is a real hang, not a theoretical one.
+ */
+#ifdef _WIN32
+static CRITICAL_SECTION rng_lock;
+static INIT_ONCE rng_lock_once = INIT_ONCE_STATIC_INIT;
+
+static BOOL CALLBACK init_rng_lock_callback(PINIT_ONCE o, PVOID p, PVOID *c) {
+    (void)o; (void)p; (void)c;
+    InitializeCriticalSection(&rng_lock);
+    return TRUE;
+}
+#else
+static pthread_mutex_t rng_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif
+#endif
+
+static void lock_rng(void) {
+#ifdef NOSTR_FEATURE_THREADING
+#ifdef _WIN32
+    InitOnceExecuteOnce(&rng_lock_once, init_rng_lock_callback, NULL, NULL);
+    EnterCriticalSection(&rng_lock);
+#else
+    pthread_mutex_lock(&rng_lock);
+#endif
+#endif
+}
+
+static void unlock_rng(void) {
+#ifdef NOSTR_FEATURE_THREADING
+#ifdef _WIN32
+    LeaveCriticalSection(&rng_lock);
+#else
+    pthread_mutex_unlock(&rng_lock);
+#endif
+#endif
+}
 
 static void lock_ctx_init(void) {
 #ifdef NOSTR_FEATURE_THREADING
@@ -121,7 +163,7 @@ int nostr_random_bytes(uint8_t *buf, size_t len) {
      * with respect to the non-volatile writes into rng_ctr_drbg, so another core
      * could observe the flag set before the context was visible.
      */
-    lock_ctx_init();
+    lock_rng();
     if (!rng_initialized) {
         mbedtls_entropy_init(&rng_entropy);
         mbedtls_ctr_drbg_init(&rng_ctr_drbg);
@@ -130,7 +172,7 @@ int nostr_random_bytes(uint8_t *buf, size_t len) {
              * struct and drops the accumulator mbedtls_md_setup() allocated. */
             mbedtls_ctr_drbg_free(&rng_ctr_drbg);
             mbedtls_entropy_free(&rng_entropy);
-            unlock_ctx_init();
+            unlock_rng();
             return 0;
         }
         rng_initialized = 1;
@@ -144,13 +186,13 @@ int nostr_random_bytes(uint8_t *buf, size_t len) {
     while (len > 0) {
         size_t chunk = len > MBEDTLS_CTR_DRBG_MAX_REQUEST ? MBEDTLS_CTR_DRBG_MAX_REQUEST : len;
         if (mbedtls_ctr_drbg_random(&rng_ctr_drbg, buf, chunk) != 0) {
-            unlock_ctx_init();
+            unlock_rng();
             return 0;
         }
         buf += chunk;
         len -= chunk;
     }
-    unlock_ctx_init();
+    unlock_rng();
     return 1;
 #else
     while (len > 0) {

--- a/src/key.c
+++ b/src/key.c
@@ -106,20 +106,52 @@ int nostr_random_bytes(uint8_t *buf, size_t len) {
      * software layer here can detect that. Enable an entropy source before
      * generating keys.
      */
+    /*
+     * The lock is held across the DRAW, not just initialisation.
+     * mbedtls_ctr_drbg_random() mutates the generator's counter and key, and its
+     * own mutex is compiled out unless MBEDTLS_THREADING_C is set, which ESP-IDF
+     * leaves off by default (components/mbedtls/Kconfig: "default n"). The
+     * esp_fill_random() this replaced was reentrant, so without this the change
+     * would introduce a data race on dual-core parts: two tasks generating keys
+     * concurrently could be handed the same AES-CTR block, i.e. identical private
+     * keys or identical BIP-340 aux_rand.
+     *
+     * Taking the lock unconditionally also fixes the fast-path read of
+     * rng_initialized, which had no acquire barrier: `volatile` orders nothing
+     * with respect to the non-volatile writes into rng_ctr_drbg, so another core
+     * could observe the flag set before the context was visible.
+     */
+    lock_ctx_init();
     if (!rng_initialized) {
-        lock_ctx_init();
-        if (!rng_initialized) {
-            mbedtls_entropy_init(&rng_entropy);
-            mbedtls_ctr_drbg_init(&rng_ctr_drbg);
-            if (mbedtls_ctr_drbg_seed(&rng_ctr_drbg, mbedtls_entropy_func, &rng_entropy, NULL, 0) != 0) {
-                unlock_ctx_init();
-                return 0;
-            }
-            rng_initialized = 1;
+        mbedtls_entropy_init(&rng_entropy);
+        mbedtls_ctr_drbg_init(&rng_ctr_drbg);
+        if (mbedtls_ctr_drbg_seed(&rng_ctr_drbg, mbedtls_entropy_func, &rng_entropy, NULL, 0) != 0) {
+            /* Free both, or the next attempt's mbedtls_entropy_init() memsets the
+             * struct and drops the accumulator mbedtls_md_setup() allocated. */
+            mbedtls_ctr_drbg_free(&rng_ctr_drbg);
+            mbedtls_entropy_free(&rng_entropy);
+            unlock_ctx_init();
+            return 0;
         }
-        unlock_ctx_init();
+        rng_initialized = 1;
     }
-    return mbedtls_ctr_drbg_random(&rng_ctr_drbg, buf, len) == 0 ? 1 : 0;
+
+    /* Chunked: mbedtls_ctr_drbg_random() refuses more than
+     * MBEDTLS_CTR_DRBG_MAX_REQUEST (1024) bytes and does not split internally.
+     * nostr_random_bytes takes a size_t and the esp_fill_random() it replaced
+     * accepted any length, so without this a caller asking for >1KB would start
+     * failing. Mirrors the OpenSSL branch below. */
+    while (len > 0) {
+        size_t chunk = len > MBEDTLS_CTR_DRBG_MAX_REQUEST ? MBEDTLS_CTR_DRBG_MAX_REQUEST : len;
+        if (mbedtls_ctr_drbg_random(&rng_ctr_drbg, buf, chunk) != 0) {
+            unlock_ctx_init();
+            return 0;
+        }
+        buf += chunk;
+        len -= chunk;
+    }
+    unlock_ctx_init();
+    return 1;
 #else
     while (len > 0) {
         int chunk = (len > INT_MAX) ? INT_MAX : (int)len;

--- a/src/key.c
+++ b/src/key.c
@@ -22,9 +22,6 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/sha256.h>
-#ifdef ESP_PLATFORM
-#include <esp_random.h>
-#endif
 #else
 #include <openssl/rand.h>
 #include <openssl/err.h>
@@ -78,19 +75,37 @@ static void unlock_ctx_init(void) {
 }
 
 #ifdef HAVE_MBEDTLS
-#ifndef ESP_PLATFORM
 static mbedtls_entropy_context rng_entropy;
 static mbedtls_ctr_drbg_context rng_ctr_drbg;
 static volatile int rng_initialized = 0;
 #endif
-#endif
 
 int nostr_random_bytes(uint8_t *buf, size_t len) {
 #ifdef HAVE_MBEDTLS
-#ifdef ESP_PLATFORM
-    esp_fill_random(buf, len);
-    return 1;
-#else
+    /*
+     * One path for every mbedTLS target, ESP32 included.
+     *
+     * This used to special-case ESP_PLATFORM to call esp_fill_random() and
+     * `return 1` unconditionally -- the only backend here incapable of
+     * reporting failure, feeding private key generation (nostr_key_generate),
+     * BIP-39 mnemonic entropy (hd_key.c), and BIP-340 aux_rand (event.c).
+     * Callers all check the return value, so the failure simply never arrived.
+     *
+     * The special case was never needed. ESP-IDF defines
+     * MBEDTLS_ENTROPY_HARDWARE_ALT for every non-Linux target and supplies
+     * mbedtls_hardware_poll() backed by esp_fill_random(), so mbedtls_entropy_func
+     * resolves to the hardware RNG on ESP32 exactly as it does elsewhere. This is
+     * the same construction ESP-IDF's own TLS stack uses. Going through CTR-DRBG
+     * adds a real error return, plus mbedTLS's entropy conditioning, and removes a
+     * platform divergence rather than adding one.
+     *
+     * NOTE FOR ESP32 CONSUMERS: this makes the RNG *fail loudly*, not magically
+     * strong. esp_fill_random() only yields true random numbers while an entropy
+     * source is running -- the RF subsystem, or bootloader_random_enable(). An
+     * air-gapped device that brings up neither draws pseudo-random bytes, and no
+     * software layer here can detect that. Enable an entropy source before
+     * generating keys.
+     */
     if (!rng_initialized) {
         lock_ctx_init();
         if (!rng_initialized) {
@@ -105,7 +120,6 @@ int nostr_random_bytes(uint8_t *buf, size_t len) {
         unlock_ctx_init();
     }
     return mbedtls_ctr_drbg_random(&rng_ctr_drbg, buf, len) == 0 ? 1 : 0;
-#endif
 #else
     while (len > 0) {
         int chunk = (len > INT_MAX) ? INT_MAX : (int)len;

--- a/src/nip44.c
+++ b/src/nip44.c
@@ -9,24 +9,17 @@
 #ifdef HAVE_MBEDTLS
 #include <mbedtls/base64.h>
 #include <mbedtls/cipher.h>
-#ifdef ESP_PLATFORM
-#include <esp_random.h>
-#define RAND_bytes(buf, len) (esp_fill_random(buf, len), 1)
-#else
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
-static int RAND_bytes(uint8_t* buf, size_t len) {
-    mbedtls_entropy_context entropy;
-    mbedtls_ctr_drbg_context ctr_drbg;
-    mbedtls_entropy_init(&entropy);
-    mbedtls_ctr_drbg_init(&ctr_drbg);
-    int ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, NULL, 0);
-    if (ret == 0) ret = mbedtls_ctr_drbg_random(&ctr_drbg, buf, len);
-    mbedtls_ctr_drbg_free(&ctr_drbg);
-    mbedtls_entropy_free(&entropy);
-    return ret == 0 ? 1 : 0;
-}
-#endif
+/*
+ * Use the library's own RNG rather than a local shim. This file previously had
+ * two: an ESP macro that discarded esp_fill_random()'s (absent) status and
+ * hardcoded success, and a non-ESP function that seeded and freed a fresh
+ * CTR-DRBG on every call. The first meant a NIP-44 nonce could be drawn from an
+ * unchecked source with no way to fail -- and a repeated nonce under a fixed
+ * conversation key is ChaCha20 keystream reuse, which is worse than a weak
+ * keygen draw. Same pattern event.c and nip26.c already use.
+ */
+extern int nostr_random_bytes(uint8_t* buf, size_t len);
+#define RAND_bytes(buf, len) nostr_random_bytes((buf), (len))
 #else
 #include <openssl/rand.h>
 #include <openssl/evp.h>
@@ -289,14 +282,10 @@ nostr_error_t nostr_nip44_encrypt(const nostr_privkey* sender_privkey, const nos
 
     nostr_error_t ret = NOSTR_OK;
 
-#ifdef ESP_PLATFORM
-    esp_fill_random(nonce, NIP44_NONCE_SIZE);
-#else
     if (RAND_bytes(nonce, NIP44_NONCE_SIZE) != 1) {
         ret = NOSTR_ERR_MEMORY;
         goto encrypt_cleanup;
     }
-#endif
 
     if (pad_plaintext((const uint8_t*)plaintext, plaintext_len,
                      &padded_plaintext, &padded_len) != 0) {


### PR DESCRIPTION
## Summary
`nostr_random_bytes()` was structurally incapable of reporting failure on ESP32. This removes the ESP special case entirely so every mbedTLS target takes the same CTR-DRBG path, which has a real error return.

## The defect

`src/key.c`, before:

```c
int nostr_random_bytes(uint8_t *buf, size_t len) {
#ifdef HAVE_MBEDTLS
#ifdef ESP_PLATFORM
    esp_fill_random(buf, len);
    return 1;          // never anything else
```

Every other backend can fail: `mbedtls_ctr_drbg_random()` returns non-zero, OpenSSL's `RAND_bytes()` returns 0. Only the ESP path always claimed success, while `include/nostr.h` documents the function as "cryptographically secure random bytes".

Everything downstream of it is key material:

| Call site | Generates |
|---|---|
| `key.c` (`nostr_key_generate`, noscrypt ctx) | **private keys** |
| `hd_key.c` | **BIP-39 mnemonic entropy** |
| `event.c` | signing randomness, BIP-340 `aux_rand` |
| `nip26.c` | delegated signing |

All eight call sites already check `!= 1`, so the failure path existed everywhere — it just could never be reached on ESP32.

`idf_component.yml` declares `esp32, esp32s2, esp32s3, esp32c3, esp32c6`, so this affects every ESP consumer of the library, not one application.

## Why deleting the special case is the right fix

I checked ESP-IDF's own source rather than guessing at a workaround:

- `components/mbedtls/port/include/mbedtls/esp_config.h:253` defines `MBEDTLS_ENTROPY_HARDWARE_ALT` unconditionally for every non-Linux target.
- `components/mbedtls/port/esp_hardware.c:19` supplies `mbedtls_hardware_poll()`, which is `esp_fill_random()`.
- `components/esp-tls/esp_tls_mbedtls.c:106` — ESP-IDF's own TLS stack — seeds with the ordinary `mbedtls_ctr_drbg_seed(mbedtls_entropy_func, &entropy, ...)` and checks the return.

So `mbedtls_entropy_func` already resolves to the hardware RNG on ESP32. The special case was never required. Removing it gives a real error return, adds mbedTLS's entropy conditioning, and deletes a platform divergence instead of introducing a new API contract or poking chip registers, which were the two alternatives I considered and rejected.

Net effect is a smaller file: the `#ifdef ESP_PLATFORM` branch, its `#endif`, and the now-unused `<esp_random.h>` include are gone, and the CTR-DRBG statics are no longer excluded on ESP.

## What this does NOT do, stated plainly

This makes the RNG **fail loudly, not become strong**. `esp_fill_random()` yields true random numbers only while an entropy source is running — the RF subsystem, or `bootloader_random_enable()`. An air-gapped device that brings up neither still draws pseudo-random bytes, and no software layer in this library can detect that. The code comment says so at the call site, because a reader who sees CTR-DRBG could reasonably assume the problem is solved.

## Test plan
- [x] **ESP32-S3 build via `test/esp-idf` succeeds** against the same refs CI uses (`noscrypt@45fcbef`, `secp256k1-frost@746dbbe`) — this is the path the change touches
- [x] Symbol check on the linked ELF confirms the new path is really wired: `nostr_random_bytes`, `mbedtls_ctr_drbg_seed`, `mbedtls_ctr_drbg_random`, `mbedtls_entropy_func` and `mbedtls_hardware_poll` are all present, and `esp_fill_random` is now reached only through `mbedtls_hardware_poll` rather than from `key.c`
- [ ] Host build not run locally: it needs a built `libnoscrypt`, and the sibling checkout here is on an unrelated branch. It fails identically with and without this change, so the failure is environmental. CI covers it

---

## Review round

Two independent reviews ran. Both found real problems, and **the first version of this change introduced two new defects of its own**. Neither would have been caught by CI, which for this file is build-only.

### Blocker 1 — I introduced a self-deadlock

`nostr_init()` takes `ctx_init_lock` (`key.c:171`) and, still holding it, calls `nostr_random_bytes()` to seed the noscrypt context (`key.c:185`). Once the RNG started taking that same lock, the first API call on every ESP target would hang forever.

This is not theoretical, and I verified each link rather than reasoning about it:

- `CMakeLists.txt:53` passes `-DNOSTR_FEATURE_THREADING=0`, but `key.c` guards with `#ifdef`, which `=0` satisfies. Confirmed in the generated `compile_commands.json`: `NOSTR_FEATURE_THREADING=0` is present, and `pthread_mutex_lock`/`pthread_mutex_unlock` are linked into the ELF.
- ESP-IDF pthread mutexes default to `PTHREAD_MUTEX_NORMAL` (`components/pthread/pthread.c:624`) and block on `portMAX_DELAY` rather than returning `EDEADLK`.

Fixed with a **dedicated `rng_lock`, separate from `ctx_init_lock`**. Verified on the linked image: `nostr_random_bytes` calls only `lock_rng`/`unlock_rng`, and the two mutexes are distinct objects (`rng_lock` at `3fc92b88`, `ctx_init_lock` at `3fc92b8c`).

### Blocker 2 — I introduced a data race

`mbedtls_ctr_drbg_random()` mutates the generator's counter and key. Its internal mutex is compiled out unless `MBEDTLS_THREADING_C` is set, and ESP-IDF leaves that `default n` (`components/mbedtls/Kconfig:1188`; the guard is `ctr_drbg.c:702`). The `esp_fill_random()` this replaces was reentrant. So the first version would have let two tasks on a dual-core part interleave inside the DRBG and receive overlapping keystream — **identical private keys or identical BIP-340 `aux_rand`**.

The lock is now held across the draw, not just the seeding. That also fixes the double-checked-locking read of `rng_initialized`, which had no acquire barrier: `volatile` orders nothing with respect to the non-volatile writes into the context.

### Blocker 3 — the same defect was still live in NIP-44, in a sharper place

`nip44.c` had `#define RAND_bytes(buf, len) (esp_fill_random(buf, len), 1)` and drew the **NIP-44 nonce** through it unchecked. A repeated nonce under a fixed conversation key is ChaCha20 keystream reuse — worse than a weak keygen draw. Fixing `key.c` while leaving that would have undercut the whole rationale, and my original PR description did not even list it.

Both the ESP macro and the non-ESP shim (which seeded and freed a whole CTR-DRBG per call) are gone; the file now uses `nostr_random_bytes`, matching `event.c` and `nip26.c`. Verified on the image: `esp_fill_random` is now called from exactly one place, `mbedtls_hardware_poll`.

### Also fixed
- **`>1024`-byte regression.** `mbedtls_ctr_drbg_random` returns `REQUEST_TOO_BIG` above `MBEDTLS_CTR_DRBG_MAX_REQUEST` (1024) and does not split. `nostr_random_bytes` is public API taking `size_t`, and `esp_fill_random` accepted any length. Now chunked, mirroring the OpenSSL branch.
- **Seed-failure leak.** `mbedtls_ctr_drbg_seed` failing returned without freeing, so a retry's `mbedtls_entropy_init` would memset the struct and drop the accumulator allocation. Both contexts are freed now.
- **Stale `<esp_random.h>`** removed from `event.c`.

### Verified clean by review, recorded so it is not re-litigated
The ESP-IDF entropy claim holds: `MBEDTLS_ENTROPY_HARDWARE_ALT` is unconditional for non-Linux targets and **no Kconfig option can disable it**; `esp_hardware.c` even carries `#error "MBEDTLS_ENTROPY_HARDWARE_ALT should always be set in ESP-IDF"`. Preprocessor nesting is balanced in all three files across every build configuration, and `HAVE_MBEDTLS` is set only in the `if(ESP_PLATFORM)` branch so an ESP build can never fall into the OpenSSL path. NIP-44 MAC-then-decrypt ordering, length validation, and `secure_wipe` coverage were all reviewed and found sound.

### Known and not fixed here
- The changed branch has **no test coverage and host CI never compiles it** — `HAVE_MBEDTLS` is ESP-only and the ESP job is build-only with no QEMU or hardware run. A host `USE_MBEDTLS` build option plus a fault-injection seam is the right answer and is filed separately.
- New `.bss` (~450 B) and transient stack (~500 B, from `ctr_drbg_reseed_internal`'s 384-byte `seed[]`) on ESP where `esp_fill_random` used none. Fine against the 8192-byte main task here; tight for a consumer generating keys on a 2 KB task. Filed.
- `nip17.c:33` fails open to the current timestamp on RNG failure — a metadata-privacy weakening, host-only, filed.

## Test plan (updated)
- [x] ESP32-S3 build green after every change, against the refs CI uses
- [x] **Deadlock disproved on the image**: `nostr_random_bytes` calls only `lock_rng`/`unlock_rng`; `rng_lock` and `ctx_init_lock` are distinct objects
- [x] **NIP-44 bypass disproved on the image**: `esp_fill_random` is reached only via `mbedtls_hardware_poll`
- [x] Threading assumption confirmed empirically, not assumed: `NOSTR_FEATURE_THREADING=0` present in `compile_commands.json`, `pthread_mutex_lock/unlock` linked
- [ ] No on-device run: this library has no hardware or QEMU test job
