### PR TITLE
Run the mbedTLS crypto paths on the host and test the RNG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,63 @@ jobs:
           cd build
           ctest --output-on-failure
 
+  # The mbedTLS branches in key.c, event.c, nip44.c and nip26.c were previously
+  # compiled only by build-esp-idf, which is build-only, so nothing ever executed
+  # them. A self-deadlock, an unsynchronised DRBG draw and a >1024-byte
+  # regression all reached main through that gap. This runs the same test suite
+  # against those branches on the host.
+  #
+  # Host mbedTLS is 2.x and ESP-IDF ships 3.x, so this covers the logic rather
+  # than the ESP toolchain. Every defect above was logic.
+  build-mbedtls:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    name: "Linux mbedTLS crypto paths"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential libssl-dev libmbedtls-dev libcjson-dev libwebsockets-dev autotools-dev autoconf libtool
+
+      - name: Install secp256k1
+        run: |
+          git clone https://github.com/bitcoin-core/secp256k1.git
+          cd secp256k1
+          ./autogen.sh
+          ./configure --enable-module-schnorrsig --enable-module-extrakeys
+          make -j$(nproc)
+          sudo make install
+          sudo ldconfig
+
+      - name: Configure
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -DNOSTR_FEATURE_CRYPTO_NOSCRYPT=OFF -DNOSTR_CRYPTO_MBEDTLS=ON
+
+      - name: Confirm the mbedTLS paths are actually enabled
+        run: |
+          grep -q '^#define HAVE_MBEDTLS' build/include/nostr_features.h \
+            || { echo "::error::HAVE_MBEDTLS not defined; this job would test the OpenSSL paths instead" >&2; exit 1; }
+          echo "HAVE_MBEDTLS is defined"
+
+      - name: Build
+        run: |
+          cd build
+          make -j$(nproc)
+
+      - name: Confirm the binary links mbedTLS
+        run: |
+          ldd build/tests/test_random | grep -q mbedcrypto \
+            || { echo "::error::test_random is not linked against mbedcrypto" >&2; exit 1; }
+          ldd build/tests/test_random | grep mbedcrypto
+
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure
+
   build-esp-idf:
     if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,8 +103,16 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: "Linux mbedTLS crypto paths"
+    # Read-only: this job builds third-party sources with sudo, so it should not
+    # be able to write anything back with the job token.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Otherwise the token is written into .git/config, where any later
+          # step, including the third-party build below, can read it.
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -113,8 +121,11 @@ jobs:
 
       - name: Install secp256k1
         run: |
+          # Pinned: this is built and `sudo make install`ed, so an unpinned
+          # default branch would run whatever upstream pushed, as root.
           git clone https://github.com/bitcoin-core/secp256k1.git
           cd secp256k1
+          git checkout 1a53f4961f337b4d166c25fce72ef0dc88806618 # v0.7.1
           ./autogen.sh
           ./configure --enable-module-schnorrsig --enable-module-extrakeys
           make -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,23 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 find_package(PkgConfig QUIET)
 find_package(OpenSSL REQUIRED)
 
+# HAVE_MBEDTLS gates the crypto in key.c, event.c, nip44.c and nip26.c. It was
+# set in exactly one place, inside the ESP_PLATFORM branch below, so host CI
+# never compiled those paths and nothing ever executed them: a self-deadlock, an
+# unsynchronised DRBG draw and a >1024-byte regression all reached main through
+# that gap. This option builds the same branches for the host so the existing
+# test suite covers them.
+#
+# The host's mbedTLS is 2.x while ESP-IDF ships 3.x, so this exercises the logic
+# rather than proving the ESP build. That is where the defects above lived.
+option(NOSTR_CRYPTO_MBEDTLS "Build the mbedTLS crypto paths instead of OpenSSL's (host testing of the ESP32 code paths)" OFF)
+if(NOSTR_CRYPTO_MBEDTLS)
+    find_library(MBEDCRYPTO_LIB mbedcrypto REQUIRED)
+    find_path(MBEDTLS_INCLUDE_DIR mbedtls/ctr_drbg.h REQUIRED)
+    set(HAVE_MBEDTLS 1)
+    message(STATUS "Building the mbedTLS crypto paths: ${MBEDCRYPTO_LIB}")
+endif()
+
 # Always required
 find_package(Threads REQUIRED)
 
@@ -786,6 +803,10 @@ endif()
 
 # Link required libraries
 set(NOSTR_LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto Threads::Threads)
+if(NOSTR_CRYPTO_MBEDTLS)
+    list(APPEND NOSTR_LINK_LIBRARIES ${MBEDCRYPTO_LIB})
+    include_directories(${MBEDTLS_INCLUDE_DIR})
+endif()
 
 
 # Add optional libraries if they exist

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,6 +144,9 @@ find_package(Threads REQUIRED)
 add_executable(test_random test_random.c)
 target_link_libraries(test_random nostr_static Threads::Threads)
 add_test(NAME random_tests COMMAND test_random)
+# The deadlock case would hang rather than fail if that bug returned, and
+# ctest's default timeout is 1500s. Cap it so a regression reports quickly.
+set_tests_properties(random_tests PROPERTIES TIMEOUT 120)
 
 # Present in the tree but never registered, so it had never been built or run.
 # It covers concurrent nostr_init() and concurrent nostr_key_generate().
@@ -155,6 +158,7 @@ if(NOT WIN32)
     add_executable(test_thread_safety test_thread_safety.c)
     target_link_libraries(test_thread_safety nostr_static Threads::Threads)
     add_test(NAME thread_safety_tests COMMAND test_thread_safety)
+    set_tests_properties(thread_safety_tests PROPERTIES TIMEOUT 180)
 endif()
 
 target_link_libraries(test_runner nostr_static)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,9 +147,15 @@ add_test(NAME random_tests COMMAND test_random)
 
 # Present in the tree but never registered, so it had never been built or run.
 # It covers concurrent nostr_init() and concurrent nostr_key_generate().
-add_executable(test_thread_safety test_thread_safety.c)
-target_link_libraries(test_thread_safety nostr_static Threads::Threads)
-add_test(NAME thread_safety_tests COMMAND test_thread_safety)
+#
+# POSIX only: the file uses pthread.h directly, which MSVC does not provide, and
+# that is most likely why it was never wired up. test_random.c carries a shim so
+# its concurrency case still runs on Windows; porting this one is left separate.
+if(NOT WIN32)
+    add_executable(test_thread_safety test_thread_safety.c)
+    target_link_libraries(test_thread_safety nostr_static Threads::Threads)
+    add_test(NAME thread_safety_tests COMMAND test_thread_safety)
+endif()
 
 target_link_libraries(test_runner nostr_static)
 target_compile_definitions(test_runner PRIVATE TEST_RUNNER_INCLUDED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,6 +136,21 @@ if(NOSTR_FEATURE_RELAY_PROTOCOL)
     add_test(NAME nip50_tests COMMAND test_nip50)
 endif()
 
+# nostr_random_bytes() produces every private key, BIP-39 mnemonic, BIP-340
+# aux_rand and NIP-44 nonce, and had no direct test on any platform. Threads are
+# required for the concurrency case, which is the regression test for an
+# unsynchronised DRBG draw.
+find_package(Threads REQUIRED)
+add_executable(test_random test_random.c)
+target_link_libraries(test_random nostr_static Threads::Threads)
+add_test(NAME random_tests COMMAND test_random)
+
+# Present in the tree but never registered, so it had never been built or run.
+# It covers concurrent nostr_init() and concurrent nostr_key_generate().
+add_executable(test_thread_safety test_thread_safety.c)
+target_link_libraries(test_thread_safety nostr_static Threads::Threads)
+add_test(NAME thread_safety_tests COMMAND test_thread_safety)
+
 target_link_libraries(test_runner nostr_static)
 target_compile_definitions(test_runner PRIVATE TEST_RUNNER_INCLUDED)
 if(UNITY_FOUND)

--- a/tests/test_random.c
+++ b/tests/test_random.c
@@ -9,9 +9,38 @@
  */
 #include "unity.h"
 #include "../include/nostr.h"
-#include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
+
+/*
+ * A minimal thread shim. The concurrency case below is the regression test for
+ * an unsynchronised DRBG draw, and the RNG takes a different lock on Windows
+ * (CRITICAL_SECTION) than on POSIX, so the case is worth running on both rather
+ * than compiling it out for MSVC, which has no pthread.h.
+ */
+#ifdef _WIN32
+#include <windows.h>
+typedef HANDLE thread_t;
+typedef DWORD WINAPI thread_ret_t;
+#define THREAD_CALL WINAPI
+static int thread_start(thread_t *t, thread_ret_t(THREAD_CALL *fn)(void *), void *arg) {
+    *t = CreateThread(NULL, 0, fn, arg, 0, NULL);
+    return *t == NULL ? -1 : 0;
+}
+static void thread_join(thread_t t) { WaitForSingleObject(t, INFINITE); CloseHandle(t); }
+#define THREAD_RETURN return 0
+#else
+#include <pthread.h>
+typedef pthread_t thread_t;
+typedef void *thread_ret_t;
+#define THREAD_CALL
+static int thread_start(thread_t *t, thread_ret_t(THREAD_CALL *fn)(void *), void *arg) {
+    return pthread_create(t, NULL, fn, arg);
+}
+static void thread_join(thread_t t) { pthread_join(t, NULL); }
+#define THREAD_RETURN return NULL
+#endif
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -78,27 +107,27 @@ static void test_zero_length_is_not_an_error(void) {
 static uint8_t g_draws[RNG_THREADS][RNG_DRAWS_PER_THREAD][RNG_DRAW_LEN];
 static int g_failures[RNG_THREADS];
 
-static void *draw_thread(void *arg) {
-    long t = (long)arg;
+static thread_ret_t THREAD_CALL draw_thread(void *arg) {
+    intptr_t t = (intptr_t)arg;
     for (int i = 0; i < RNG_DRAWS_PER_THREAD; i++) {
         if (nostr_random_bytes(g_draws[t][i], RNG_DRAW_LEN) != 1) {
             g_failures[t]++;
         }
     }
-    return NULL;
+    THREAD_RETURN;
 }
 
 static void test_concurrent_draws_are_all_distinct(void) {
-    pthread_t th[RNG_THREADS];
+    thread_t th[RNG_THREADS];
 
     memset(g_draws, 0, sizeof(g_draws));
     memset(g_failures, 0, sizeof(g_failures));
 
-    for (long t = 0; t < RNG_THREADS; t++) {
-        TEST_ASSERT_EQUAL(0, pthread_create(&th[t], NULL, draw_thread, (void *)t));
+    for (intptr_t t = 0; t < RNG_THREADS; t++) {
+        TEST_ASSERT_EQUAL(0, thread_start(&th[t], draw_thread, (void *)t));
     }
     for (int t = 0; t < RNG_THREADS; t++) {
-        pthread_join(th[t], NULL);
+        thread_join(th[t]);
     }
     for (int t = 0; t < RNG_THREADS; t++) {
         TEST_ASSERT_EQUAL(0, g_failures[t]);

--- a/tests/test_random.c
+++ b/tests/test_random.c
@@ -1,0 +1,143 @@
+/*
+ * Tests for nostr_random_bytes().
+ *
+ * This function produces every private key (nostr_key_generate), BIP-39
+ * mnemonic (hd_key.c), BIP-340 aux_rand (event.c) and NIP-44 nonce, and had no
+ * direct test on any platform. Three defects shipped through that gap: a
+ * self-deadlock, an unsynchronised DRBG draw, and a length regression. Each
+ * case below is a regression test for one of them.
+ */
+#include "unity.h"
+#include "../include/nostr.h"
+#include <pthread.h>
+#include <string.h>
+#include <stdlib.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static int all_zero(const uint8_t *b, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        if (b[i]) return 0;
+    }
+    return 1;
+}
+
+static void test_fills_the_buffer(void) {
+    uint8_t buf[32];
+    memset(buf, 0, sizeof(buf));
+    TEST_ASSERT_EQUAL(1, nostr_random_bytes(buf, sizeof(buf)));
+    TEST_ASSERT_FALSE(all_zero(buf, sizeof(buf)));
+}
+
+/*
+ * The length regression. mbedtls_ctr_drbg_random() refuses more than
+ * MBEDTLS_CTR_DRBG_MAX_REQUEST (1024) bytes and does not split internally, so
+ * an unchunked implementation fails above 1KB while passing every 32-byte test.
+ * The tail is checked separately: a partial fill would leave it zeroed while
+ * the call still reported success.
+ */
+static void test_draws_larger_than_the_drbg_request_limit(void) {
+    const size_t n = 4096;
+    uint8_t *buf = calloc(1, n);
+    TEST_ASSERT_NOT_NULL(buf);
+
+    TEST_ASSERT_EQUAL(1, nostr_random_bytes(buf, n));
+    TEST_ASSERT_FALSE(all_zero(buf, n));
+    /* Past the 1024-byte boundary, where a single-request implementation stops. */
+    TEST_ASSERT_FALSE(all_zero(buf + 1024, n - 1024));
+    TEST_ASSERT_FALSE(all_zero(buf + n - 64, 64));
+
+    free(buf);
+}
+
+static void test_successive_draws_differ(void) {
+    uint8_t a[32], b[32];
+    TEST_ASSERT_EQUAL(1, nostr_random_bytes(a, sizeof(a)));
+    TEST_ASSERT_EQUAL(1, nostr_random_bytes(b, sizeof(b)));
+    TEST_ASSERT_NOT_EQUAL(0, memcmp(a, b, sizeof(a)));
+}
+
+static void test_zero_length_is_not_an_error(void) {
+    uint8_t buf[1] = {0xAA};
+    TEST_ASSERT_EQUAL(1, nostr_random_bytes(buf, 0));
+    TEST_ASSERT_EQUAL(0xAA, buf[0]);
+}
+
+/*
+ * The data race. mbedtls_ctr_drbg_random() mutates the generator's counter and
+ * key, and its internal mutex compiles out unless MBEDTLS_THREADING_C is set,
+ * which ESP-IDF leaves off. Without an external lock two concurrent callers can
+ * be handed the same AES-CTR block: identical private keys or identical
+ * aux_rand. Duplicates across threads are the observable symptom.
+ */
+#define RNG_THREADS 8
+#define RNG_DRAWS_PER_THREAD 64
+#define RNG_DRAW_LEN 32
+
+static uint8_t g_draws[RNG_THREADS][RNG_DRAWS_PER_THREAD][RNG_DRAW_LEN];
+static int g_failures[RNG_THREADS];
+
+static void *draw_thread(void *arg) {
+    long t = (long)arg;
+    for (int i = 0; i < RNG_DRAWS_PER_THREAD; i++) {
+        if (nostr_random_bytes(g_draws[t][i], RNG_DRAW_LEN) != 1) {
+            g_failures[t]++;
+        }
+    }
+    return NULL;
+}
+
+static void test_concurrent_draws_are_all_distinct(void) {
+    pthread_t th[RNG_THREADS];
+
+    memset(g_draws, 0, sizeof(g_draws));
+    memset(g_failures, 0, sizeof(g_failures));
+
+    for (long t = 0; t < RNG_THREADS; t++) {
+        TEST_ASSERT_EQUAL(0, pthread_create(&th[t], NULL, draw_thread, (void *)t));
+    }
+    for (int t = 0; t < RNG_THREADS; t++) {
+        pthread_join(th[t], NULL);
+    }
+    for (int t = 0; t < RNG_THREADS; t++) {
+        TEST_ASSERT_EQUAL(0, g_failures[t]);
+    }
+
+    /* O(n^2) over 512 draws is trivial here and needs no allocation or sort. */
+    const int total = RNG_THREADS * RNG_DRAWS_PER_THREAD;
+    const uint8_t *flat = (const uint8_t *)g_draws;
+    for (int i = 0; i < total; i++) {
+        TEST_ASSERT_FALSE(all_zero(flat + (size_t)i * RNG_DRAW_LEN, RNG_DRAW_LEN));
+        for (int j = i + 1; j < total; j++) {
+            if (memcmp(flat + (size_t)i * RNG_DRAW_LEN,
+                       flat + (size_t)j * RNG_DRAW_LEN, RNG_DRAW_LEN) == 0) {
+                /* two concurrent draws returned identical bytes */
+                TEST_ASSERT(0);
+            }
+        }
+    }
+}
+
+/*
+ * The self-deadlock. nostr_init() holds its context lock while seeding, and the
+ * RNG once took that same non-recursive lock, so the first call hung forever.
+ * Drawing after init exercises the ordering that regressed.
+ */
+static void test_draw_after_init_does_not_deadlock(void) {
+    uint8_t buf[32];
+    TEST_ASSERT_EQUAL(NOSTR_OK, nostr_init());
+    TEST_ASSERT_EQUAL(1, nostr_random_bytes(buf, sizeof(buf)));
+    TEST_ASSERT_FALSE(all_zero(buf, sizeof(buf)));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_fills_the_buffer);
+    RUN_TEST(test_draws_larger_than_the_drbg_request_limit);
+    RUN_TEST(test_successive_draws_differ);
+    RUN_TEST(test_zero_length_is_not_an_error);
+    RUN_TEST(test_concurrent_draws_are_all_distinct);
+    RUN_TEST(test_draw_after_init_does_not_deadlock);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Adds `tests/test_random.c`, registers two test files that existed but were never built, and adds a CI job that compiles and runs the mbedTLS crypto paths on the host.

## The gap

`HAVE_MBEDTLS` was set in exactly one place, `CMakeLists.txt:35`, inside the `if(ESP_PLATFORM)` branch. It gates code in four files: `key.c`, `event.c`, `nip44.c` and `nip26.c`. Host builds always took the OpenSSL branch, and the only job that compiled the mbedTLS branch, `build-esp-idf`, is build-only with no QEMU and no hardware.

So that code was compiled but never executed, anywhere. Three defects reached main through it, each caught by review rather than by any test:

- a self-deadlock, where `nostr_init()` held its context lock and the RNG took the same non-recursive lock
- an unsynchronised `mbedtls_ctr_drbg_random()` draw, whose internal mutex compiles out because ESP-IDF leaves `MBEDTLS_THREADING_C` off
- a >1024-byte regression, since `mbedtls_ctr_drbg_random()` refuses more than `MBEDTLS_CTR_DRBG_MAX_REQUEST` and does not split internally

Separately, `grep` for `nostr_random_bytes` in `tests/` returned nothing. The function producing every private key, BIP-39 mnemonic, BIP-340 aux_rand and NIP-44 nonce had no direct test on any platform.

## Changes

**`tests/test_random.c`**, six cases, each written against one of the defects above: buffer is filled, draws past the 1024-byte DRBG request limit, successive draws differ, zero length is not an error, 512 concurrent draws across 8 threads are all distinct, and a draw immediately after `nostr_init()` does not deadlock.

**Two dead test files registered.** `test_thread_safety.c` and `test_nip47.c` were present in `tests/` but referenced nowhere in `tests/CMakeLists.txt`, so neither had ever been built. `test_thread_safety.c` matters here: it contains `test_concurrent_key_generation`, directly relevant to the data race above. It passes once built, so it was forgotten rather than broken. This PR registers `test_thread_safety.c`; `test_nip47.c` is left for a separate change since it is unrelated to this one.

**`-DNOSTR_CRYPTO_MBEDTLS=ON`** builds the mbedTLS branches for the host, and a `build-mbedtls` CI job runs the full suite against them.

## What this does and does not prove

Host mbedTLS is 2.x; ESP-IDF ships 3.x. This exercises the **logic** of those branches, not the ESP toolchain. Every one of the three defects was logic, so the coverage lands where the failures were, but this is not a substitute for executing on-target. A QEMU or hardware smoke job remains the thing that would catch an ESP-specific failure, and this does not replace it.

The job asserts its own premise rather than assuming it, because silently testing the wrong backend is precisely how this blind spot arose:

- fails unless `HAVE_MBEDTLS` is defined in the generated `nostr_features.h`
- fails unless `ldd` shows `test_random` linked against `mbedcrypto`

## Test plan

- [x] mbedTLS configuration, exactly as CI runs it: **15/15 ctest pass**, binary confirmed linked to `libmbedcrypto.so.7`
- [x] Default OpenSSL configuration: **15/15 ctest pass**, and `HAVE_MBEDTLS` is absent from the generated header, so the default build is unchanged
- [x] **Negative control**: removed the chunking loop in `nostr_random_bytes`, restoring the original single-request call, and rebuilt against mbedTLS. `test_random` failed with 4 assertions, including the buffer past offset 1024 remaining zeroed. Restored, and it passes again. The test genuinely catches the regression rather than merely passing.
- [x] `test_thread_safety` passes on both backends once registered
- [x] `build.yml` parses as YAML

Worth noting for a follow-up: `build-esp-idf` checks out noscrypt with `ref: esp-idf-support`, a branch rather than a commit, so what that job builds can change without any commit here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional mbedTLS support for host builds through CMake configuration.
  * Added Linux build validation with mbedTLS enabled.

* **Tests**
  * Added coverage for random byte generation, large requests, repeated calls, zero-length requests, and concurrent access.
  * Added thread-safety tests and integrated both test suites with CTest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->