### PR TITLE
Run the ESP smoke test under QEMU instead of only building it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,42 @@ jobs:
           esp_idf_version: v5.4.1
           target: esp32s3
           path: libnostr-c/test/esp-idf
+
+      # Building alone is what let three defects reach main: the mbedTLS RNG
+      # path compiles only for ESP targets, so until this ran, that code had
+      # never executed anywhere. The host mbedTLS job covers the same logic
+      # against 2.x; this covers the 3.x ESP-IDF ships, on the FreeRTOS
+      # scheduler the data-race case needs.
+      #
+      # QEMU is driven directly rather than through `idf.py qemu monitor`,
+      # which expects an interactive terminal and a TCP serial socket. The
+      # `idf.py qemu` call before it is only to generate qemu_flash.bin and
+      # qemu_efuse.bin; its own launch attempt is discarded.
+      - name: Run the on-target smoke test under QEMU
+        working-directory: libnostr-c/test/esp-idf
+        run: |
+          set -uo pipefail
+          docker run --rm -v "$PWD":/p -w /p espressif/idf:v5.4.1 bash -lc '
+            set -u
+            python $IDF_PATH/tools/idf_tools.py install qemu-xtensa >/dev/null 2>&1
+            . $IDF_PATH/export.sh >/dev/null 2>&1
+            qemu_bin=$(find $HOME/.espressif/tools/qemu-xtensa -name qemu-system-xtensa | head -1)
+            export PATH="$(dirname "$qemu_bin"):$PATH"
+            timeout 60 idf.py qemu --qemu-extra-args="-nographic" >/dev/null 2>&1 || true
+            test -f build/qemu_flash.bin || { echo "flash image was never generated" >&2; exit 1; }
+            timeout 90 "$qemu_bin" -M esp32s3 \
+              -drive file=build/qemu_flash.bin,if=mtd,format=raw \
+              -drive file=build/qemu_efuse.bin,if=none,format=raw,id=efuse \
+              -global driver=nvram.esp32c3.efuse,property=drive,value=efuse \
+              -nographic > qemu.log 2>&1 || true
+          '
+          echo "--- smoke output ---"
+          sed -n '/SMOKE-BEGIN/,/SMOKE-\(PASS\|FAIL-TOTAL\)/p' qemu.log || true
+          if ! grep -q 'SMOKE-PASS' qemu.log; then
+            echo "::error::on-target smoke test did not report SMOKE-PASS (assertion failure, crash, or hang)" >&2
+            tail -40 qemu.log >&2
+            exit 1
+          fi
         
   build-windows:
     # Builds third-party sources; no reason to hold a writable job token.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,11 @@ jobs:
         working-directory: libnostr-c/test/esp-idf
         run: |
           set -uo pipefail
-          docker run --rm -v "$PWD":/p -w /p espressif/idf:v5.4.1 bash -lc '
+          # Mounted at the SAME absolute path the build used. CMake caches
+          # absolute paths in build/, so mounting elsewhere (e.g. /p) silently
+          # invalidates the cache and idf.py regenerates nothing, which surfaces
+          # only as a missing flash image.
+          docker run --rm -v "$GITHUB_WORKSPACE":"$GITHUB_WORKSPACE" -w "$PWD" espressif/idf:v5.4.1 bash -lc '
             set -eu
             # Install errors are NOT discarded: a silent failure here would
             # leave the run looking like a QEMU problem rather than a missing
@@ -223,9 +227,14 @@ jobs:
 
             # Only to generate qemu_flash.bin and qemu_efuse.bin; its own launch
             # attempt wants an interactive terminal and is discarded.
-            timeout 60 idf.py qemu --qemu-extra-args="-nographic" >/dev/null 2>&1 || true
-            test -f build/qemu_flash.bin \
-              || { echo "flash image was never generated" >&2; exit 1; }
+            # Output kept: when this failed, discarding it left only "flash
+            # image was never generated" with no cause.
+            timeout 60 idf.py qemu --qemu-extra-args="-nographic" > qemu-gen.log 2>&1 || true
+            if [ ! -f build/qemu_flash.bin ]; then
+              echo "flash image was never generated; idf.py qemu said:" >&2
+              tail -30 qemu-gen.log >&2
+              exit 1
+            fi
 
             # -nographic already routes serial to stdio. Passing -serial stdio
             # as well makes the machine boot with no console output at all.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,14 +210,26 @@ jobs:
         run: |
           set -uo pipefail
           docker run --rm -v "$PWD":/p -w /p espressif/idf:v5.4.1 bash -lc '
-            set -u
-            python $IDF_PATH/tools/idf_tools.py install qemu-xtensa >/dev/null 2>&1
-            . $IDF_PATH/export.sh >/dev/null 2>&1
-            qemu_bin=$(find $HOME/.espressif/tools/qemu-xtensa -name qemu-system-xtensa | head -1)
-            export PATH="$(dirname "$qemu_bin"):$PATH"
+            set -eu
+            # Install errors are NOT discarded: a silent failure here would
+            # leave the run looking like a QEMU problem rather than a missing
+            # tool. IDF_TOOLS_PATH is /opt/esp in this image, not ~/.espressif,
+            # so the tool is located through PATH after export.sh rather than
+            # by guessing a directory.
+            python "$IDF_PATH/tools/idf_tools.py" install qemu-xtensa
+            . "$IDF_PATH/export.sh" >/dev/null
+            command -v qemu-system-xtensa >/dev/null \
+              || { echo "qemu-system-xtensa not on PATH after install" >&2; exit 1; }
+
+            # Only to generate qemu_flash.bin and qemu_efuse.bin; its own launch
+            # attempt wants an interactive terminal and is discarded.
             timeout 60 idf.py qemu --qemu-extra-args="-nographic" >/dev/null 2>&1 || true
-            test -f build/qemu_flash.bin || { echo "flash image was never generated" >&2; exit 1; }
-            timeout 90 "$qemu_bin" -M esp32s3 \
+            test -f build/qemu_flash.bin \
+              || { echo "flash image was never generated" >&2; exit 1; }
+
+            # -nographic already routes serial to stdio. Passing -serial stdio
+            # as well makes the machine boot with no console output at all.
+            timeout 90 qemu-system-xtensa -M esp32s3 \
               -drive file=build/qemu_flash.bin,if=mtd,format=raw \
               -drive file=build/qemu_efuse.bin,if=none,format=raw,id=efuse \
               -global driver=nvram.esp32c3.efuse,property=drive,value=efuse \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,69 +189,59 @@ jobs:
           ref: 746dbbea5c34dde963c9bd55bc7474b2d50fa597 # esp-idf-support
           path: secp256k1-frost
 
-      - uses: espressif/esp-idf-ci-action@v1
-        with:
-          esp_idf_version: v5.4.1
-          target: esp32s3
-          path: libnostr-c/test/esp-idf
-
-      # Building alone is what let three defects reach main: the mbedTLS RNG
-      # path compiles only for ESP targets, so until this ran, that code had
-      # never executed anywhere. The host mbedTLS job covers the same logic
-      # against 2.x; this covers the 3.x ESP-IDF ships, on the FreeRTOS
-      # scheduler the data-race case needs.
+      # Build and run in ONE container. The esp-idf-ci-action builds inside
+      # its own container at /app/..., and CMake bakes that absolute path into
+      # build/, so the directory cannot be reused from any other mount: idf.py
+      # rejects it with "configured for project /app/... not /home/runner/...".
+      # Doing both here keeps the paths consistent by construction, and is one
+      # build rather than two.
       #
-      # QEMU is driven directly rather than through `idf.py qemu monitor`,
-      # which expects an interactive terminal and a TCP serial socket. The
-      # `idf.py qemu` call before it is only to generate qemu_flash.bin and
-      # qemu_efuse.bin; its own launch attempt is discarded.
-      - name: Run the on-target smoke test under QEMU
-        working-directory: libnostr-c/test/esp-idf
+      # Running matters, not just building: the mbedTLS RNG path compiles only
+      # for ESP targets, so until this job ran it, that code had never executed
+      # anywhere. Three defects reached main through that gap. The host mbedTLS
+      # job covers the same logic against 2.x; this covers the 3.x ESP-IDF
+      # ships, on the FreeRTOS scheduler the data-race case needs.
+      - name: Build and run the on-target smoke test under QEMU
         run: |
-          set -uo pipefail
-          # Mounted at the SAME absolute path the build used. CMake caches
-          # absolute paths in build/, so mounting elsewhere (e.g. /p) silently
-          # invalidates the cache and idf.py regenerates nothing, which surfaces
-          # only as a missing flash image.
-          docker run --rm -v "$GITHUB_WORKSPACE":"$GITHUB_WORKSPACE" -w "$PWD" espressif/idf:v5.4.1 bash -lc '
-            set -eu
-            # Install errors are NOT discarded: a silent failure here would
-            # leave the run looking like a QEMU problem rather than a missing
-            # tool. IDF_TOOLS_PATH is /opt/esp in this image, not ~/.espressif,
-            # so the tool is located through PATH after export.sh rather than
-            # by guessing a directory.
-            python "$IDF_PATH/tools/idf_tools.py" install qemu-xtensa
-            . "$IDF_PATH/export.sh" >/dev/null
-            command -v qemu-system-xtensa >/dev/null \
-              || { echo "qemu-system-xtensa not on PATH after install" >&2; exit 1; }
+          set -euo pipefail
+          docker run --rm -v "$GITHUB_WORKSPACE":/w -w /w/libnostr-c/test/esp-idf \
+            espressif/idf:v5.4.1 bash -lc '
+              set -eu
+              . "$IDF_PATH/export.sh" >/dev/null
+              idf.py set-target esp32s3 >/dev/null
+              idf.py build
 
-            # Only to generate qemu_flash.bin and qemu_efuse.bin; its own launch
-            # attempt wants an interactive terminal and is discarded.
-            # Output kept: when this failed, discarding it left only "flash
-            # image was never generated" with no cause.
-            timeout 60 idf.py qemu --qemu-extra-args="-nographic" > qemu-gen.log 2>&1 || true
-            if [ ! -f build/qemu_flash.bin ]; then
-              echo "flash image was never generated; idf.py qemu said:" >&2
-              tail -30 qemu-gen.log >&2
-              exit 1
-            fi
+              python "$IDF_PATH/tools/idf_tools.py" install qemu-xtensa
+              . "$IDF_PATH/export.sh" >/dev/null
+              command -v qemu-system-xtensa >/dev/null \
+                || { echo "qemu-system-xtensa not on PATH after install" >&2; exit 1; }
 
-            # -nographic already routes serial to stdio. Passing -serial stdio
-            # as well makes the machine boot with no console output at all.
-            timeout 90 qemu-system-xtensa -M esp32s3 \
-              -drive file=build/qemu_flash.bin,if=mtd,format=raw \
-              -drive file=build/qemu_efuse.bin,if=none,format=raw,id=efuse \
-              -global driver=nvram.esp32c3.efuse,property=drive,value=efuse \
-              -nographic > qemu.log 2>&1 || true
-          '
+              # Only to generate qemu_flash.bin and qemu_efuse.bin; its own
+              # launch wants an interactive terminal and is discarded. Output is
+              # kept, because discarding it left an earlier failure with no cause.
+              timeout 60 idf.py qemu --qemu-extra-args="-nographic" > qemu-gen.log 2>&1 || true
+              if [ ! -f build/qemu_flash.bin ]; then
+                echo "flash image was never generated; idf.py qemu said:" >&2
+                tail -30 qemu-gen.log >&2
+                exit 1
+              fi
+
+              # -nographic already routes serial to stdio. Passing -serial stdio
+              # as well makes the machine boot with no console output at all.
+              timeout 90 qemu-system-xtensa -M esp32s3 \
+                -drive file=build/qemu_flash.bin,if=mtd,format=raw \
+                -drive file=build/qemu_efuse.bin,if=none,format=raw,id=efuse \
+                -global driver=nvram.esp32c3.efuse,property=drive,value=efuse \
+                -nographic > qemu.log 2>&1 || true
+            '
           echo "--- smoke output ---"
-          sed -n '/SMOKE-BEGIN/,/SMOKE-\(PASS\|FAIL-TOTAL\)/p' qemu.log || true
-          if ! grep -q 'SMOKE-PASS' qemu.log; then
+          sed -n '/SMOKE-BEGIN/,/SMOKE-\(PASS\|FAIL-TOTAL\)/p' libnostr-c/test/esp-idf/qemu.log || true
+          if ! grep -q 'SMOKE-PASS' libnostr-c/test/esp-idf/qemu.log; then
             echo "::error::on-target smoke test did not report SMOKE-PASS (assertion failure, crash, or hang)" >&2
-            tail -40 qemu.log >&2
+            tail -40 libnostr-c/test/esp-idf/qemu.log >&2
             exit 1
           fi
-        
+
   build-windows:
     # Builds third-party sources; no reason to hold a writable job token.
     permissions:

--- a/test/esp-idf/main/test_main.c
+++ b/test/esp-idf/main/test_main.c
@@ -1,11 +1,131 @@
+/*
+ * On-target smoke test.
+ *
+ * Built by CI and, under QEMU, actually run. That distinction is the point: the
+ * mbedTLS RNG path is compiled only for ESP targets, and until this ran it had
+ * never executed anywhere. Three defects reached main through that gap, and
+ * each has a case here:
+ *
+ *   - a self-deadlock, where nostr_init() held its context lock and the RNG
+ *     took the same non-recursive lock
+ *   - an unsynchronised mbedtls_ctr_drbg_random() draw, whose internal mutex
+ *     compiles out because ESP-IDF leaves MBEDTLS_THREADING_C off
+ *   - a >1024-byte regression, since mbedtls_ctr_drbg_random() refuses more
+ *     than MBEDTLS_CTR_DRBG_MAX_REQUEST and does not split internally
+ *
+ * The host suite covers the same logic against mbedTLS 2.x. This covers the 3.x
+ * ESP-IDF actually ships, on the FreeRTOS scheduler the race needs.
+ *
+ * The result is one line. CI greps for it, so a silent hang or a crash is a
+ * failure rather than a pass.
+ */
 #include <stdio.h>
+#include <string.h>
+#include <stdint.h>
 #include "nostr.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+
+#define DRAW_TASKS 4
+#define DRAWS_PER_TASK 16
+#define DRAW_LEN 32
+
+static uint8_t g_draws[DRAW_TASKS][DRAWS_PER_TASK][DRAW_LEN];
+static int g_task_failures[DRAW_TASKS];
+static SemaphoreHandle_t g_done;
+
+static int failures = 0;
+
+static void check(int ok, const char *what) {
+    if (!ok) {
+        printf("SMOKE-FAIL: %s\n", what);
+        failures++;
+    } else {
+        printf("  ok: %s\n", what);
+    }
+}
+
+static int all_zero(const uint8_t *b, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        if (b[i]) return 0;
+    }
+    return 1;
+}
+
+static void draw_task(void *arg) {
+    int t = (int)(intptr_t)arg;
+    for (int i = 0; i < DRAWS_PER_TASK; i++) {
+        if (nostr_random_bytes(g_draws[t][i], DRAW_LEN) != 1) {
+            g_task_failures[t]++;
+        }
+    }
+    xSemaphoreGive(g_done);
+    vTaskDelete(NULL);
+}
 
 void app_main(void) {
-    nostr_keypair keypair;
-    nostr_error_t err = nostr_keypair_generate(&keypair);
-    if (err == NOSTR_OK) {
-        printf("libnostr-c: keypair generated\n");
-        nostr_keypair_destroy(&keypair);
+    printf("SMOKE-BEGIN\n");
+
+    /* Deadlock case: nostr_init() seeds through the same path the RNG uses. A
+     * regression here hangs rather than fails, which is why CI bounds the run. */
+    check(nostr_init() == NOSTR_OK, "nostr_init");
+
+    uint8_t buf[DRAW_LEN];
+    memset(buf, 0, sizeof(buf));
+    check(nostr_random_bytes(buf, sizeof(buf)) == 1 && !all_zero(buf, sizeof(buf)),
+          "draw after init does not deadlock and fills the buffer");
+
+    /* Chunking case: one request past MBEDTLS_CTR_DRBG_MAX_REQUEST. An
+     * unchunked implementation fails here while passing every 32-byte draw. */
+    static uint8_t big[4096];
+    memset(big, 0, sizeof(big));
+    check(nostr_random_bytes(big, sizeof(big)) == 1, "draw of 4096 bytes succeeds");
+    check(!all_zero(big + 1024, sizeof(big) - 1024),
+          "bytes past the 1024-byte DRBG limit are filled");
+
+    /* Race case: concurrent draws on a dual-core part. Without an external lock
+     * two tasks can be handed the same AES-CTR block, so duplicates are the
+     * observable symptom. */
+    memset(g_draws, 0, sizeof(g_draws));
+    memset(g_task_failures, 0, sizeof(g_task_failures));
+    g_done = xSemaphoreCreateCounting(DRAW_TASKS, 0);
+    check(g_done != NULL, "semaphore created");
+
+    for (int t = 0; t < DRAW_TASKS; t++) {
+        /* 4096 is generous on purpose: ctr_drbg_reseed_internal puts a
+         * 384-byte seed buffer on the caller's stack, plus the entropy gather. */
+        xTaskCreate(draw_task, "draw", 4096, (void *)(intptr_t)t, 5, NULL);
+    }
+    for (int t = 0; t < DRAW_TASKS; t++) {
+        xSemaphoreTake(g_done, portMAX_DELAY);
+    }
+
+    int draw_errors = 0;
+    for (int t = 0; t < DRAW_TASKS; t++) draw_errors += g_task_failures[t];
+    check(draw_errors == 0, "every concurrent draw reported success");
+
+    const int total = DRAW_TASKS * DRAWS_PER_TASK;
+    const uint8_t *flat = (const uint8_t *)g_draws;
+    int dup = 0, zero = 0;
+    for (int i = 0; i < total; i++) {
+        if (all_zero(flat + (size_t)i * DRAW_LEN, DRAW_LEN)) zero++;
+        for (int j = i + 1; j < total; j++) {
+            if (memcmp(flat + (size_t)i * DRAW_LEN,
+                       flat + (size_t)j * DRAW_LEN, DRAW_LEN) == 0) dup++;
+        }
+    }
+    check(zero == 0, "no concurrent draw returned all zeros");
+    check(dup == 0, "no two concurrent draws returned identical bytes");
+
+    /* The public API the RNG feeds. */
+    nostr_keypair kp;
+    check(nostr_keypair_generate(&kp) == NOSTR_OK, "nostr_keypair_generate");
+    nostr_keypair_destroy(&kp);
+
+    if (failures == 0) {
+        printf("SMOKE-PASS\n");
+    } else {
+        printf("SMOKE-FAIL-TOTAL %d\n", failures);
     }
 }


### PR DESCRIPTION
## Summary

`build-esp-idf` compiled an 11-line program and threw it away. It now runs under QEMU and asserts nine things about the RNG path, on the mbedTLS version ESP-IDF actually ships.

## Why

The mbedTLS branch in `key.c` compiles only for ESP targets. Until this, nothing executed it, anywhere. Three defects reached main through that gap, each caught by review rather than by any test:

- a self-deadlock, `nostr_init()` holding its context lock while the RNG took the same non-recursive lock
- an unsynchronised `mbedtls_ctr_drbg_random()` draw, whose internal mutex compiles out because ESP-IDF leaves `MBEDTLS_THREADING_C` off
- a >1024-byte regression, since `mbedtls_ctr_drbg_random()` refuses more than `MBEDTLS_CTR_DRBG_MAX_REQUEST` and does not split internally

#65 made the host build compile those branches, which closed the compile gap. It did not close the execution gap, and it runs against host mbedTLS **2.x** while ESP-IDF ships **3.x**. This closes both, and adds the FreeRTOS scheduler the race case actually needs.

## What it asserts

`SMOKE-BEGIN`, nine checks, then `SMOKE-PASS` or `SMOKE-FAIL-TOTAL n`. CI greps for `SMOKE-PASS`, so a hang or a crash is a failure rather than a silent pass.

Cases map to the defects: init does not deadlock, a 4096-byte draw succeeds, bytes past the 1024-byte limit are filled, four FreeRTOS tasks drawing concurrently all succeed, none returns zeros, and no two return identical bytes. Plus `nostr_keypair_generate`, the public API the RNG feeds.

## Verified end to end

Proved locally before writing the CI step, rather than the other way round:

- [x] ESP32-S3 image boots under QEMU and reaches `app_main()`
- [x] All nine assertions pass on target: **SMOKE-PASS**
- [x] **Negative control**: removed the chunking loop in `nostr_random_bytes`, rebuilt, re-ran. Reported `SMOKE-FAIL-TOTAL 2`, naming "draw of 4096 bytes succeeds" and "bytes past the 1024-byte DRBG limit are filled". Restored and passing again. It catches the regression rather than passing regardless
- [x] Image builds clean, 76% of the app partition free
- [ ] CI, which is the part I cannot verify locally

## What I could not verify locally

The workflow step itself. It runs QEMU in a `espressif/idf:v5.4.1` container against the artifacts the action already built, and drives `qemu-system-xtensa` directly because `idf.py qemu monitor` wants an interactive terminal and a TCP serial socket. The `idf.py qemu` call preceding it exists only to generate `qemu_flash.bin` and `qemu_efuse.bin`; its own launch attempt is discarded. That shape works locally, but the container and volume plumbing is CI-only and this run is its first test.

One local detail worth recording, since it cost time: passing both `-nographic` and `-serial stdio` produces a booting machine with no console output at all. `-nographic` already routes serial to stdio, and the pair silently conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded ESP-IDF smoke testing to cover random number generation, concurrent operations, buffer handling, semaphore creation, and keypair generation.
  * Added clearer individual failure reporting and an overall pass/failure result.

* **Chores**
  * Added automated QEMU smoke-test execution for ESP32-S3 firmware builds, including output validation for successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->