### PR TITLE
Report a failed task create instead of waiting forever

### DIFF
--- a/test/esp-idf/main/test_main.c
+++ b/test/esp-idf/main/test_main.c
@@ -92,14 +92,28 @@ void app_main(void) {
     g_done = xSemaphoreCreateCounting(DRAW_TASKS, 0);
     check(g_done != NULL, "semaphore created");
 
+    int started = 0;
     for (int t = 0; t < DRAW_TASKS; t++) {
         /* 4096 is generous on purpose: ctr_drbg_reseed_internal puts a
          * 384-byte seed buffer on the caller's stack, plus the entropy gather. */
-        xTaskCreate(draw_task, "draw", 4096, (void *)(intptr_t)t, 5, NULL);
+        if (xTaskCreate(draw_task, "draw", 4096, (void *)(intptr_t)t, 5, NULL) == pdPASS) {
+            started++;
+        }
     }
-    for (int t = 0; t < DRAW_TASKS; t++) {
-        xSemaphoreTake(g_done, portMAX_DELAY);
+    /* Unchecked, a failed create meant one fewer xSemaphoreGive and a
+     * portMAX_DELAY wait that never returns: a CI timeout with no message,
+     * which is the failure mode this whole file exists to avoid. */
+    check(started == DRAW_TASKS, "all draw tasks were created");
+
+    int joined = 0;
+    for (int t = 0; t < started; t++) {
+        /* Bounded rather than portMAX_DELAY, so a task that hangs reports a
+         * missing result instead of stalling the run to the job timeout. */
+        if (xSemaphoreTake(g_done, pdMS_TO_TICKS(10000)) == pdTRUE) {
+            joined++;
+        }
     }
+    check(joined == started, "every draw task finished within the timeout");
 
     int draw_errors = 0;
     for (int t = 0; t < DRAW_TASKS; t++) draw_errors += g_task_failures[t];


### PR DESCRIPTION
## Summary

Addresses the review finding on #67 that I merged past. `xTaskCreate`'s return value was unchecked, so a failed create meant one fewer `xSemaphoreGive` and a `portMAX_DELAY` wait that never returns.

## Why it matters here specifically

The failure surfaced only as a CI job timeout with no message. That is the exact shape this file exists to catch, reproduced inside it: the smoke test checks that the RNG fails loudly, while itself having a path that fails silently.

Two changes:

- `xTaskCreate` is checked against `pdPASS` and reported as `SMOKE-FAIL: all draw tasks were created`
- the join waits `pdMS_TO_TICKS(10000)` rather than `portMAX_DELAY`, and reports `every draw task finished within the timeout`, so a task that hangs produces a named failure rather than stalling to the job limit

Eleven assertions now, up from nine.

## Test plan

- [x] QEMU, restored code: **SMOKE-PASS**, 11/11
- [x] **Negative control**: forced task creation to fail by requesting a 999999-word stack. Reports `SMOKE-FAIL: all draw tasks were created` and **completes** rather than hanging. Before this change the same condition would have blocked at `portMAX_DELAY` until the job timeout
- [x] Restored and passing again
- [ ] CI

The two consequential failures in the control run, zeroed buffers and no distinct draws, are expected: no draws happened, so those assertions correctly report the downstream effect.

Worth noting the review was right and I should have read it before merging #67 rather than after.