### PR TITLE
Fail closed when the NIP-17 timestamp cannot be fuzzed

### DIFF
--- a/src/nip17.c
+++ b/src/nip17.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <time.h>
 #include <openssl/rand.h>
+#include <openssl/err.h>
 
 #ifdef NOSTR_FEATURE_CRYPTO_NOSCRYPT
 #include <noscrypt.h>
@@ -25,17 +26,30 @@ extern secp256k1_context* secp256k1_ctx;
 
 extern nostr_error_t nostr_init(void);
 
-static int64_t random_timestamp_past_two_days()
+/*
+ * NIP-17 back-dates seals and gift wraps by a random offset so a relay observer
+ * cannot correlate send times. Returning the exact current time on RNG failure
+ * removed that property silently: the event still sent, still validated, and
+ * the timing metadata it exists to hide was published in the clear.
+ *
+ * Fails closed instead. The caller aborts rather than emitting an event whose
+ * timestamp is not fuzzed.
+ */
+static nostr_error_t random_timestamp_past_two_days(int64_t* out)
 {
-    int64_t now = (int64_t)time(NULL);
     uint32_t random_offset;
-    
+
     if (RAND_bytes((unsigned char*)&random_offset, sizeof(random_offset)) != 1) {
-        return now;
+        ERR_clear_error();
+        /* NOSTR_ERR_MEMORY is what key.c and event.c already return for an RNG
+         * failure. Semantically loose, but consistent; a dedicated code would
+         * be a public enum change and belongs in its own commit. */
+        return NOSTR_ERR_MEMORY;
     }
-    
+
     random_offset %= TWO_DAYS_SECONDS;
-    return now - random_offset;
+    *out = (int64_t)time(NULL) - random_offset;
+    return NOSTR_OK;
 }
 
 nostr_error_t nostr_nip17_create_rumor(nostr_event** rumor, uint16_t kind, const nostr_key* pubkey, 
@@ -104,7 +118,12 @@ nostr_error_t nostr_nip17_create_seal(nostr_event** seal, const nostr_event* rum
     }
     
     (*seal)->kind = KIND_SEAL;
-    (*seal)->created_at = random_timestamp_past_two_days();
+    err = random_timestamp_past_two_days(&(*seal)->created_at);
+    if (err != NOSTR_OK) {
+        nostr_event_destroy(*seal);
+        *seal = NULL;
+        return err;
+    }
     
     /* Derive pubkey from privkey */
 #ifdef NOSTR_FEATURE_CRYPTO_NOSCRYPT
@@ -214,7 +233,12 @@ nostr_error_t nostr_nip17_create_gift_wrap(nostr_event** wrap, const nostr_event
     }
     
     (*wrap)->kind = KIND_GIFT_WRAP;
-    (*wrap)->created_at = random_timestamp_past_two_days();
+    err = random_timestamp_past_two_days(&(*wrap)->created_at);
+    if (err != NOSTR_OK) {
+        nostr_event_destroy(*wrap);
+        *wrap = NULL;
+        return err;
+    }
     memcpy(&(*wrap)->pubkey, &ephemeral_pubkey, sizeof(nostr_key));
     
     err = nostr_event_set_content(*wrap, encrypted_seal);

--- a/src/nip17.c
+++ b/src/nip17.c
@@ -122,6 +122,7 @@ nostr_error_t nostr_nip17_create_seal(nostr_event** seal, const nostr_event* rum
     if (err != NOSTR_OK) {
         nostr_event_destroy(*seal);
         *seal = NULL;
+        free(encrypted_rumor);
         return err;
     }
     
@@ -237,6 +238,8 @@ nostr_error_t nostr_nip17_create_gift_wrap(nostr_event** wrap, const nostr_event
     if (err != NOSTR_OK) {
         nostr_event_destroy(*wrap);
         *wrap = NULL;
+        secure_wipe(&ephemeral_privkey, sizeof(ephemeral_privkey));
+        free(encrypted_seal);
         return err;
     }
     memcpy(&(*wrap)->pubkey, &ephemeral_pubkey, sizeof(nostr_key));


### PR DESCRIPTION
## Summary

`random_timestamp_past_two_days()` returned the exact current time when `RAND_bytes` failed. It now propagates the error and both callers abort.

## Why this is a real weakening, not a nit

NIP-17 back-dates seals and gift wraps by a random offset for one reason: so a relay observer cannot correlate send times. Collapsing to `now()` on RNG failure removes exactly that property, and removes it **silently**. The event still builds, still validates, still sends. The only observable difference is that the timing metadata the construction exists to hide is published in the clear.

Same shape as the RNG defects fixed in #63: a failure path that returns a plausible value instead of an error, so nothing downstream can tell the difference.

Both call sites, the seal at `nip17.c:121` and the gift wrap at `:236`, now destroy the partially built event, null the out-param, and return the error rather than emitting an event whose timestamp is not fuzzed.

## On the error code

Returns `NOSTR_ERR_MEMORY`, which is what `key.c:229` and `event.c:627` already return for an RNG failure. Semantically loose for this case, but consistent with the codebase, and a dedicated code would be a public enum change that belongs in its own commit rather than riding along here.

I first wrote `NOSTR_ERR_CRYPTO_FAILED`, which does not exist. The compiler caught it; worth noting because the fix was to read what the codebase actually does rather than to invent what it ought to.

## Test plan

- [x] Compiles clean
- [x] Both call sites verified to propagate; `grep` for `return now;` returns **0**, so no path emits an unfuzzed timestamp
- [x] Full suite: **15/15 pass**
- [x] `openssl/err.h` added for `ERR_clear_error`, matching how the OpenSSL branch in `key.c` clears the error queue after a failed draw
- [ ] CI

Closes libnostr-c-lp6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when secure timestamp generation fails.
  * Prevented incomplete seal and gift-wrap events from being returned after an internal error.
  * Enhanced error handling to avoid using fallback timestamps in failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->