### PR TITLE
Document the ESP stack cost of seeding the DRBG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,11 @@ external/
 # Performance benchmarking
 performance_baseline.txt
 callgrind.out*
+# ESP-IDF build byproducts. `idf.py build` and the QEMU smoke test generate
+# these in test/esp-idf; sdkconfig in particular is per-developer (target,
+# flash size) and does not belong in the tree. sdkconfig.defaults is tracked
+# and is what CI and a fresh checkout actually use.
+test/esp-idf/sdkconfig
+test/esp-idf/sdkconfig.old
+test/esp-idf/dependencies.lock
+test/esp-idf/managed_components/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,47 @@ The following table lists supported platforms and cryptographic backends:
 | Linux    | noscrypt, secp256k1 | GCC/Clang | ✅ Tested |
 | macOS    | noscrypt, secp256k1 | Clang | ✅ Tested |
 | Windows  | noscrypt, secp256k1 | MSVC | ✅ Tested |
-| ESP-IDF  | noscrypt, mbedtls | ESP32/S2/S3/C3/C6, v5.0+ | ✅ Tested |
+| ESP-IDF  | noscrypt, mbedtls | ESP32/S2/S3/C3/C6, v5.0+ | ✅ Tested, run under QEMU |
+
+### ESP-IDF stack requirement
+
+On ESP targets the RNG goes through a cached mbedTLS CTR-DRBG rather than
+`esp_fill_random()`, so that a failed draw can be reported instead of silently
+returning zeros. That costs stack in the task that happens to seed it.
+
+**Call `nostr_random_bytes()`, `nostr_key_generate()` or any signing entry point
+from a task with at least 4 KB of stack.** The first call in the process seeds
+the DRBG, and `ctr_drbg_reseed_internal()` puts a 384-byte
+`MBEDTLS_CTR_DRBG_MAX_SEED_INPUT` buffer on the *caller's* stack
+(`mbedtls/library/ctr_drbg.c:452`), plus the entropy gather. Roughly 500 bytes
+transient that `esp_fill_random()` never needed. It is re-paid every
+`MBEDTLS_CTR_DRBG_RESEED_INTERVAL` draws, which is 10000 by default, so a task
+that seeds successfully once can still overflow much later.
+
+Seeding lazily from whichever task draws first means the cost lands wherever
+that happens to be. Calling `nostr_init()` early, from a task you control the
+depth of, makes it predictable.
+
+Fixed cost is small: 500 bytes of `.bss` for the two contexts, measured from a
+built ESP32-S3 image (`rng_entropy` 420 B, `rng_ctr_drbg` 76 B,
+`rng_initialized` 4 B). The entropy accumulator also mallocs its message-digest
+context on first use and never frees it, which is one-time rather than a growing
+leak.
+
+This is measured, not estimated. Under QEMU on ESP32-S3:
+
+| first caller | result |
+| ------------ | ------ |
+| 2 KB task drawing from an already-seeded DRBG | passes |
+| 2 KB task that seeds the DRBG itself | `Guru Meditation Error: Core 1 panic'ed (LoadProhibited)` |
+| 8 KB task (`app_main`) seeding, then 2 KB tasks drawing | passes |
+
+So the hazard is specifically the *first* caller, which is why seeding from a
+task whose depth you control is worth doing deliberately.
+
+`test/esp-idf` sets `CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192`, so CI seeds from
+`app_main` with headroom and will not catch a consumer that seeds from a smaller
+task.
 
 ## Getting started
 Please use the following links to obtain packages and extended documentation.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ On ESP targets the RNG goes through a cached mbedTLS CTR-DRBG rather than
 `esp_fill_random()`, so that a failed draw can be reported instead of silently
 returning zeros. That costs stack in the task that happens to seed it.
 
-**Call `nostr_random_bytes()`, `nostr_key_generate()` or any signing entry point
-from a task with at least 4 KB of stack.** The first call in the process seeds
+**Call `nostr_random_bytes()`, `nostr_key_generate()`, `nostr_keypair_generate()`
+or any signing entry point from a task with at least 4 KB of stack.**
+(`nostr_keypair_generate()` delegates to `nostr_key_generate()`, so either
+reaches the same draw.) The first call in the process seeds
 the DRBG, and `ctr_drbg_reseed_internal()` puts a 384-byte
 `MBEDTLS_CTR_DRBG_MAX_SEED_INPUT` buffer on the *caller's* stack
 (`mbedtls/library/ctr_drbg.c:452`), plus the entropy gather. Roughly 500 bytes
@@ -70,8 +72,14 @@ This is measured, not estimated. Under QEMU on ESP32-S3:
 | first caller | result |
 | ------------ | ------ |
 | 2 KB task drawing from an already-seeded DRBG | passes |
-| 2 KB task that seeds the DRBG itself | `Guru Meditation Error: Core 1 panic'ed (LoadProhibited)` |
+| 2 KB task that seeds the DRBG itself | crashes, `Guru Meditation Error: Core 1 panic'ed (LoadProhibited)` |
+| 3 KB task that seeds | passes |
+| 4 KB task that seeds | passes |
 | 8 KB task (`app_main`) seeding, then 2 KB tasks drawing | passes |
+
+The threshold is between 2 KB and 3 KB on this build. 4 KB is the recommendation
+because it leaves margin for your own frames on top of the seed, not because
+3 KB was observed to fail.
 
 So the hazard is specifically the *first* caller, which is why seeding from a
 task whose depth you control is worth doing deliberately.


### PR DESCRIPTION
## Summary

Documents the stack requirement the mbedTLS CTR-DRBG introduced on ESP targets, and ignores the build byproducts the QEMU smoke test generates.

## The hazard

#63 moved the ESP RNG from `esp_fill_random()`, which has no state, onto a cached CTR-DRBG so a failed draw can be reported instead of silently returning zeros. Seeding costs stack in whichever task calls first: `ctr_drbg_reseed_internal()` puts a 384-byte `MBEDTLS_CTR_DRBG_MAX_SEED_INPUT` buffer on the **caller's** stack, plus the entropy gather.

Verified against the ESP-IDF sources rather than quoted from memory: `mbedtls/library/ctr_drbg.c:452` declares the buffer, and `ctr_drbg.h` confirms `MAX_SEED_INPUT 384`, `MAX_REQUEST 1024`, `RESEED_INTERVAL 10000`.

## Measured, not estimated

Fixed cost, read from a built ESP32-S3 image with `nm`:

| symbol | bytes |
| ------ | ----- |
| `rng_entropy` | 420 |
| `rng_ctr_drbg` | 76 |
| `rng_initialized` | 4 |
| **total .bss** | **500** |

My original estimate on the issue was ~450 B, so this corrects it upward.

Stack behaviour, run under QEMU:

| first caller | result |
| ------------ | ------ |
| 2 KB task drawing from an already-seeded DRBG | passes |
| 2 KB task that seeds the DRBG itself | `Guru Meditation Error: Core 1 panic’ed (LoadProhibited)` |
| 8 KB `app_main` seeding, then 2 KB tasks drawing | passes |

That middle row is the point, and it corrected my first experiment. I initially just shrank the smoke test's task stack to 2 KB and it passed, which looked like the hazard was not real. It passed because `app_main` had already seeded with 8 KB of stack, so the task never paid the seed cost. Re-running with a 2 KB task as the genuine first caller crashes. The hazard is specifically the first caller, which is why the README recommends seeding deliberately from a task whose depth you control.

## .gitignore

Executing action: all (aliases: build)
Running cmake in directory /home/kyle/Documents/GitHub/libnostr-c/build
Executing "cmake -G Ninja -DPYTHON_DEPS_CHECKED=1 -DPYTHON=/home/kyle/.espressif/python_env/idf5.4_py3.12_env/bin/python -DESP_PLATFORM=1 -DCCACHE_ENABLE=0 /home/kyle/Documents/GitHub/libnostr-c"... and the QEMU step generate `sdkconfig`, `dependencies.lock` and `managed_components/` in `test/esp-idf`. None were ignored, so they were one `git add -A` away from being committed. `sdkconfig` in particular is per-developer. `sdkconfig.defaults` stays tracked, since that is what CI and a fresh checkout use.

## Test plan

- [x] Figures verified against ESP-IDF's own mbedTLS sources
- [x] `.bss` measured from a built ELF, not estimated
- [x] Stack claims reproduced under QEMU, including the crash
- [x] Smoke test restored and passing after the experiments: **SMOKE-PASS**
- [x] Generated files now ignored; `sdkconfig.defaults` still tracked
- [ ] CI

Closes libnostr-c-j31.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added ESP-IDF platform guidance covering stack requirements for random number generation, key generation, and signing.
  - Documented cached cryptographic random generator behavior, initialization, memory usage, measured QEMU results, and CI task configuration.

- **Chores**
  - Updated ignore rules to exclude generated ESP-IDF configuration, dependency lock, and managed component files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
