### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.2.1] - 2026-08-03
+
+### Security
+- Fail closed when the NIP-17 timestamp cannot be fuzzed. A failed RNG draw previously let sealing and wrapping continue with an unfuzzed timestamp; both call sites now destroy the partial event, clear the out-parameter and wipe the ephemeral private key
+- Let the ESP32 RNG report failure like every other backend, so a degraded draw surfaces instead of being silently accepted
+
+### Fixed
+- Report a failed FreeRTOS task create instead of waiting forever on a semaphore that can no longer be given
+- Build macOS against a supported OpenSSL; openssl@1.1 has been end of life since September 2023 and was removed from Homebrew
+- Fix Windows CI by removing the hardcoded VS 2022 generator
+- Correct the license badge to MIT, matching LICENSE
+
+### Changed
+- Run the ESP-IDF smoke test under QEMU rather than only building it, so the mbedTLS RNG path is executed on the target it is compiled for
+- Exercise the mbedTLS crypto paths on the host and test the RNG directly
+- Pin every third-party source CI builds
+- Document the ESP stack cost of seeding the DRBG
+
 ## [0.2.0] - 2026-02-14
 
 ### Security

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(ESP_PLATFORM)
     return()
 endif()
 
-project(libnostr-c VERSION 0.2.0 LANGUAGES C)
+project(libnostr-c VERSION 0.2.1 LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "0.2.1"
 description: "Lightweight C library for the Nostr protocol"
 url: "https://github.com/privkeyio/libnostr-c"
 repository: "https://github.com/privkeyio/libnostr-c.git"


### PR DESCRIPTION
Version bump for v0.2.1. Ten commits have landed since v0.2.0, four of them touching shipped sources, and two of those are fail-closed fixes that consumers on the current release do not have.

## Why now

`src/nip17.c` previously continued sealing and wrapping when the RNG draw for timestamp fuzzing failed, producing an event with an unfuzzed timestamp rather than an error. Both call sites now destroy the partial event, clear the out-parameter, free the intermediate ciphertexts and wipe the ephemeral private key.

`src/key.c` now lets the ESP32 RNG report failure the way every other backend does, so a degraded draw surfaces instead of being silently accepted.

Anyone consuming this library by release is on v0.2.0 without either. Consumers pinning by commit already have them.

## Changes

- `CMakeLists.txt`: project version to 0.2.1
- `idf_component.yml`: component version to 0.2.1, so the ESP-IDF component registry matches
- `CHANGELOG.md`: 0.2.1 entry covering the security fixes, the FreeRTOS task-create fix, the macOS OpenSSL and Windows CI fixes, and the QEMU smoke test

`SOVERSION` stays at 1: no ABI change.

## Verification

Configured and built from clean, producing `libnostr.so.0.2.1`, which confirms the bump reaches the built artifact rather than only the manifests. Full suite run: 15 of 15 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog details for version 0.2.1, including security, build, CI, testing, and dependency documentation updates.

* **Release**
  * Updated the project and component version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->