### PR TITLE
Bump the Zig manifest version alongside the others

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .libnostr,
-    .version = "0.2.0",
+    .version = "0.2.1",
     .fingerprint = 0x5fdc996820f59181,
     .paths = .{
         "build.zig",


### PR DESCRIPTION
`build.zig.zon` still declared 0.2.0 after #71 moved `CMakeLists.txt` and `idf_component.yml` to 0.2.1, so a Zig consumer would have seen a version that disagreed with every other manifest in the tree.

Missed in #71 because the search for version strings filtered by extension and `.zon` was not in the list. Re-run without a filter, this was the only remaining occurrence outside CHANGELOG history.

All three now agree:

| file | version |
| --- | --- |
| `CMakeLists.txt` | 0.2.1 |
| `idf_component.yml` | 0.2.1 |
| `build.zig.zon` | 0.2.1 |

Verified the manifest still parses with `zig build --help`. Merging before v0.2.1 is tagged, so the release ships consistent metadata.
